### PR TITLE
rework to rubocop gem

### DIFF
--- a/.github/workflows/gem-push.yml
+++ b/.github/workflows/gem-push.yml
@@ -1,0 +1,28 @@
+name: Ruby Gem
+
+on:
+  push:
+    branches: [ master ]
+
+jobs:
+  build:
+    name: Build + Publish
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Ruby 2.6
+      uses: actions/setup-ruby@v1
+      with:
+        ruby-version: 2.6.x
+
+    - name: Publish to GPR
+      run: |
+        mkdir -p $HOME/.gem
+        touch $HOME/.gem/credentials
+        chmod 0600 $HOME/.gem/credentials
+        printf -- "---\n:github: ${GEM_HOST_API_KEY}\n" > $HOME/.gem/credentials
+        gem build *.gemspec
+        gem push --KEY github --host https://rubygems.pkg.github.com/compeon *.gem
+      env:
+        GEM_HOST_API_KEY: "Bearer ${{secrets.GITHUB_TOKEN}}"

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,11 @@
+/.bundle/
+/.yardoc
+/_yardoc/
+/coverage/
+/doc/
+/pkg/
+/spec/reports/
+/tmp/
+
+# rspec failure tracking
+.rspec_status

--- a/.rspec
+++ b/.rspec
@@ -1,0 +1,3 @@
+--format documentation
+--color
+--require spec_helper

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,33 +1,3 @@
-require:
-  - 'rubocop-performance'
-
-AllCops:
-  NewCops: enable
-
-Bundler/OrderedGems:
-  Enabled: false
-
-Layout/ClassStructure:
-  Enabled: true
-
-Layout/HashAlignment:
-  EnforcedHashRocketStyle: key
-  EnforcedColonStyle: key
-
-Lint/MissingSuper:
-  Enabled: false
-
-Metrics/BlockLength:
-  Enabled: false
-
-Metrics/ClassLength:
-  Enabled: false
-
-Metrics/ModuleLength:
-  Enabled: false
-
-Style/Documentation:
-  Enabled: false
-
-Style/ReturnNil:
-  Enabled: true
+Naming/FileName:
+ Exclude:
+   - lib/rubocop-compeon.rb

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,7 @@
+source "https://rubygems.org"
+
+# Specify your gem's dependencies in rubocop-compeon.gemspec
+gemspec
+
+gem "rake", "~> 12.0"
+gem "rspec", "~> 3.0"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,58 @@
+PATH
+  remote: .
+  specs:
+    rubocop-compeon (1.0.0)
+      rubocop
+      rubocop-performance
+
+GEM
+  remote: https://rubygems.org/
+  specs:
+    ast (2.4.1)
+    diff-lcs (1.4.4)
+    parallel (1.19.2)
+    parser (2.7.1.4)
+      ast (~> 2.4.1)
+    rainbow (3.0.0)
+    rake (12.3.3)
+    regexp_parser (1.7.1)
+    rexml (3.2.4)
+    rspec (3.9.0)
+      rspec-core (~> 3.9.0)
+      rspec-expectations (~> 3.9.0)
+      rspec-mocks (~> 3.9.0)
+    rspec-core (3.9.2)
+      rspec-support (~> 3.9.3)
+    rspec-expectations (3.9.2)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.9.0)
+    rspec-mocks (3.9.1)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.9.0)
+    rspec-support (3.9.3)
+    rubocop (0.89.1)
+      parallel (~> 1.10)
+      parser (>= 2.7.1.1)
+      rainbow (>= 2.2.2, < 4.0)
+      regexp_parser (>= 1.7)
+      rexml
+      rubocop-ast (>= 0.3.0, < 1.0)
+      ruby-progressbar (~> 1.7)
+      unicode-display_width (>= 1.4.0, < 2.0)
+    rubocop-ast (0.3.0)
+      parser (>= 2.7.1.4)
+    rubocop-performance (1.7.1)
+      rubocop (>= 0.82.0)
+    ruby-progressbar (1.10.1)
+    unicode-display_width (1.7.0)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  rake (~> 12.0)
+  rspec (~> 3.0)
+  rubocop-compeon!
+
+BUNDLED WITH
+   2.1.2

--- a/README.md
+++ b/README.md
@@ -1,24 +1,40 @@
-# COMPEON Ruby Styleguide
+# Rubocop::Compeon
 
-## Rubocop defaults
+Welcome to your new gem! In this directory, you'll find the files you need to be able to package up your Ruby library into a gem. Put your Ruby code in the file `lib/rubocop/compeon`. To experiment with that code, run `bin/console` for an interactive prompt.
 
-This repo contains the COMPEON default Rubocop configuration which is shared across all projects.
+TODO: Delete this and the text above, and describe your gem
 
-### Usecase
+## Installation
 
-Add this at the begin of your `.rubocop.yml` file.
+Add this line to your application's Gemfile:
 
-```yaml
-inherit_from:
-  - 'https://raw.githubusercontent.com/COMPEON/ruby-styleguide/master/.rubocop.yml'
+```ruby
+gem 'rubocop-compeon', require: false
 ```
 
-### Customization
+And then execute:
 
-If you want to overwrite some of the defaults, you might need to add this too.
+    $ bundle install
 
-```yaml
-inherit_mode:
-  merge:
-    - Exclude
-```
+Or install it yourself as:
+
+    $ gem install rubocop-compeon
+
+## Usage
+
+TODO: Write usage instructions here
+
+## Development
+
+After checking out the repo, run `bin/setup` to install dependencies. Then, run `rake spec` to run the tests. You can also run `bin/console` for an interactive prompt that will allow you to experiment.
+
+To install this gem onto your local machine, run `bundle exec rake install`. To release a new version, update the version number in `version.rb`, and then run `bundle exec rake release`, which will create a git tag for the version, push git commits and tags, and push the `.gem` file to [rubygems.org](https://rubygems.org).
+
+## Contributing
+
+Bug reports and pull requests are welcome on GitHub at https://github.com/COMPEON/ruby-styleguide.
+
+
+## License
+
+The gem is available as open source under the terms of the [MIT License](https://opensource.org/licenses/MIT).

--- a/Rakefile
+++ b/Rakefile
@@ -1,0 +1,34 @@
+require "bundler/gem_tasks"
+require "rspec/core/rake_task"
+
+RSpec::Core::RakeTask.new(:spec)
+
+task :default => :spec
+
+require 'rspec/core/rake_task'
+
+RSpec::Core::RakeTask.new(:spec) do |spec|
+  spec.pattern = FileList['spec/**/*_spec.rb']
+end
+
+desc 'Generate a new cop with a template'
+task :new_cop, [:cop] do |_task, args|
+  require 'rubocop'
+
+  cop_name = args.fetch(:cop) do
+    warn 'usage: bundle exec rake new_cop[Department/Name]'
+    exit!
+  end
+
+  github_user = `git config github.user`.chop
+  github_user = 'your_id' if github_user.empty?
+
+  generator = RuboCop::Cop::Generator.new(cop_name, github_user)
+
+  generator.write_source
+  generator.write_spec
+  generator.inject_require(root_file_path: 'lib/rubocop/cop/compeon_cops.rb')
+  generator.inject_config(config_file_path: 'config/default.yml')
+
+  puts generator.todo
+end

--- a/bin/console
+++ b/bin/console
@@ -3,12 +3,5 @@
 require "bundler/setup"
 require "rubocop/compeon"
 
-# You can add fixtures and/or initialization code here to make experimenting
-# with your gem easier. You can also use a different console, if you like.
-
-# (If you use this, don't forget to add pry to your Gemfile!)
-# require "pry"
-# Pry.start
-
 require "irb"
 IRB.start(__FILE__)

--- a/bin/console
+++ b/bin/console
@@ -1,0 +1,14 @@
+#!/usr/bin/env ruby
+
+require "bundler/setup"
+require "rubocop/compeon"
+
+# You can add fixtures and/or initialization code here to make experimenting
+# with your gem easier. You can also use a different console, if you like.
+
+# (If you use this, don't forget to add pry to your Gemfile!)
+# require "pry"
+# Pry.start
+
+require "irb"
+IRB.start(__FILE__)

--- a/bin/setup
+++ b/bin/setup
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+set -euo pipefail
+IFS=$'\n\t'
+set -vx
+
+bundle install
+
+# Do any other automated setup that you need to do here

--- a/config/default.yml
+++ b/config/default.yml
@@ -1,0 +1,33 @@
+require:
+  - 'rubocop-performance'
+
+AllCops:
+  NewCops: enable
+
+Bundler/OrderedGems:
+  Enabled: false
+
+Layout/ClassStructure:
+  Enabled: true
+
+Layout/HashAlignment:
+  EnforcedHashRocketStyle: key
+  EnforcedColonStyle: key
+
+Lint/MissingSuper:
+  Enabled: false
+
+Metrics/BlockLength:
+  Enabled: false
+
+Metrics/ClassLength:
+  Enabled: false
+
+Metrics/ModuleLength:
+  Enabled: false
+
+Style/Documentation:
+  Enabled: false
+
+Style/ReturnNil:
+  Enabled: true

--- a/lib/rubocop-compeon.rb
+++ b/lib/rubocop-compeon.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+require 'rubocop'
+
+require_relative 'rubocop/compeon'
+require_relative 'rubocop/compeon/version'
+require_relative 'rubocop/compeon/inject'
+
+RuboCop::Compeon::Inject.defaults!
+
+require_relative 'rubocop/cop/compeon_cops'

--- a/lib/rubocop/compeon.rb
+++ b/lib/rubocop/compeon.rb
@@ -1,0 +1,14 @@
+require "rubocop/compeon/version"
+
+module RuboCop
+  module Compeon
+    class Error < StandardError; end
+    # Your code goes here...
+    PROJECT_ROOT   = Pathname.new(__dir__).parent.parent.expand_path.freeze
+    CONFIG_DEFAULT = PROJECT_ROOT.join('config', 'default.yml').freeze
+    CONFIG         = YAML.safe_load(CONFIG_DEFAULT.read).freeze
+
+    private_constant(:CONFIG_DEFAULT, :PROJECT_ROOT)
+  end
+end
+

--- a/lib/rubocop/compeon.rb
+++ b/lib/rubocop/compeon.rb
@@ -3,7 +3,6 @@ require "rubocop/compeon/version"
 module RuboCop
   module Compeon
     class Error < StandardError; end
-    # Your code goes here...
     PROJECT_ROOT   = Pathname.new(__dir__).parent.parent.expand_path.freeze
     CONFIG_DEFAULT = PROJECT_ROOT.join('config', 'default.yml').freeze
     CONFIG         = YAML.safe_load(CONFIG_DEFAULT.read).freeze
@@ -11,4 +10,3 @@ module RuboCop
     private_constant(:CONFIG_DEFAULT, :PROJECT_ROOT)
   end
 end
-

--- a/lib/rubocop/compeon/inject.rb
+++ b/lib/rubocop/compeon/inject.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+# The original code is from https://github.com/rubocop-hq/rubocop-rspec/blob/master/lib/rubocop/rspec/inject.rb
+# See https://github.com/rubocop-hq/rubocop-rspec/blob/master/MIT-LICENSE.md
+module RuboCop
+  module Compeon
+    # Because RuboCop doesn't yet support plugins, we have to monkey patch in a
+    # bit of our configuration.
+    module Inject
+      def self.defaults!
+        path = CONFIG_DEFAULT.to_s
+        hash = ConfigLoader.send(:load_yaml_configuration, path)
+        config = Config.new(hash, path).tap(&:make_excludes_absolute)
+        puts "configuration from #{path}" if ConfigLoader.debug?
+        config = ConfigLoader.merge_with_default(config, path)
+        ConfigLoader.instance_variable_set(:@default_configuration, config)
+      end
+    end
+  end
+end

--- a/lib/rubocop/compeon/version.rb
+++ b/lib/rubocop/compeon/version.rb
@@ -1,0 +1,5 @@
+module RuboCop
+  module Compeon
+    VERSION = "1.0.0"
+  end
+end

--- a/lib/rubocop/cop/compeon_cops.rb
+++ b/lib/rubocop/cop/compeon_cops.rb
@@ -1,0 +1,1 @@
+# frozen_string_literal: true

--- a/rubocop-compeon.gemspec
+++ b/rubocop-compeon.gemspec
@@ -1,0 +1,27 @@
+require_relative 'lib/rubocop/compeon/version'
+
+Gem::Specification.new do |spec|
+  spec.name          = "rubocop-compeon"
+  spec.version       = RuboCop::Compeon::VERSION
+  spec.authors       = ["Timo Schilling"]
+  spec.email         = ["timo@schilling.io"]
+
+  spec.summary       = %q{Compeon RuboCop config.}
+  spec.license       = "MIT"
+  spec.required_ruby_version = Gem::Requirement.new(">= 2.3.0")
+
+  spec.metadata["allowed_push_host"] = "https://rubygems.pkg.github.com/COMPEON/"
+
+  # Specify which files should be added to the gem when it is released.
+  # The `git ls-files -z` loads the files in the RubyGem that have been added into git.
+  spec.files         = Dir.chdir(File.expand_path('..', __FILE__)) do
+    `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
+  end
+  spec.bindir        = "exe"
+  spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
+  spec.require_paths = ["lib"]
+
+  spec.add_runtime_dependency "rubocop"
+  spec.add_runtime_dependency "rubocop-performance"
+end
+

--- a/spec/rubocop/compeon_spec.rb
+++ b/spec/rubocop/compeon_spec.rb
@@ -1,0 +1,9 @@
+RSpec.describe Rubocop::Compeon do
+  it "has a version number" do
+    expect(Rubocop::Compeon::VERSION).not_to be nil
+  end
+
+  it "does something useful" do
+    expect(false).to eq(true)
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+require 'rubocop-compeon'
+require 'rubocop/rspec/support'
+
+RSpec.configure do |config|
+  config.include RuboCop::RSpec::ExpectOffense
+
+  config.disable_monkey_patching!
+  config.raise_errors_for_deprecations!
+  config.raise_on_warning = true
+  config.fail_if_no_examples = true
+
+  config.order = :random
+  Kernel.srand config.seed
+end


### PR DESCRIPTION
according to our devweek discussion we rework our rubocop style guide as rubocop extension gem to get  versioned custom configs.

The code comes from an rubocop suggested generator and is equal to rubocop-rspec.